### PR TITLE
Fix conditional compilation for deferred device initialization

### DIFF
--- a/samples/src/main.c
+++ b/samples/src/main.c
@@ -51,7 +51,7 @@ void gyr_high_rate(const struct device *dev, const struct sensor_trigger *trigge
 
 int main(void)
 {
-#if DEVICE_DT_DEFER(DT_NODELABEL(bno0550))
+#if Z_DEVICE_DT_FLAGS(DT_NODELABEL(bno0550)) & DEVICE_FLAG_INIT_DEFERRED
 	k_sleep(K_MSEC(BNO055_TIMING_STARTUP));
 	device_init(bno055_dev);
 #endif


### PR DESCRIPTION
This pull request updates the device initialization to use a new macro for deferred device initialization with Zephyr 4.2.0. Instead of the previous macro, it now checks device flags directly for deferred initialization. Cf: https://github.com/zephyrproject-rtos/zephyr/commit/f44a30109cfb3eab5992b09f34bc61d2ccc047b1

Device initialization logic update:

* [`samples/src/main.c`](diffhunk://#diff-27cacc5a2e725a617f34db9e6ac77888a913b6b1e23267ed00e5a15fbd2f5be5L54-R54): Replaced `DEVICE_DT_DEFER(DT_NODELABEL(bno0550))` with a check using `Z_DEVICE_DT_FLAGS(bno0550) & DEVICE_FLAG_INIT_DEFERRED` to determine if the device initialization is deferred.